### PR TITLE
Josh changes

### DIFF
--- a/lib/transducers.rb
+++ b/lib/transducers.rb
@@ -34,7 +34,7 @@ end
   .reduce([], &filtering { |v| v.even? }.call(concats))
   # => [6, 12]
 
-# gem install ramda-ruby
+# `gem install ramda-ruby`
 require 'ramda'
 
 [1,2,3,4,5].reduce([], &Ramda.pipe(

--- a/spec/find_spec.rb
+++ b/spec/find_spec.rb
@@ -2,8 +2,13 @@ require_relative '../lib/find'
 
 RSpec.describe 'select' do
   it 'applies a function to every element of a list' do
-    expect(find([1,2,3]) { |v| v.even? }).to eq(2)
+    expect(find([1,2,3])  { |v| v.odd? }).to eq(1)
+    expect(find2([1,2,3]) { |v| v.odd? }).to eq(1)
+    expect(find3([1,2,3]) { |v| v.odd? }).to eq(1)
+
+    expect(find([1,2,3])  { |v| v.even? }).to eq(2)
     expect(find2([1,2,3]) { |v| v.even? }).to eq(2)
+    expect(find3([1,2,3]) { |v| v.even? }).to eq(2)
   end
 
   it 'returns nil if nothing was found' do

--- a/spec/transducer_spec.rb
+++ b/spec/transducer_spec.rb
@@ -10,4 +10,24 @@ RSpec.describe 'transducers' do
       expect(maps_result).to eq([2,4,6])
     end
   end
+
+  context 'acceptance' do
+    example 'mapping and filtering' do
+      result = [1,2,3,4,5]
+        .reduce([], &mapping   { |v| v * 3   }.call(concats))
+        .reduce([], &filtering { |v| v.even? }.call(concats))
+      expect(result).to eq [6, 12]
+    end
+
+    example 'works with Ramda' do
+      # `gem install ramda-ruby`
+      require 'ramda'
+      result = [1,2,3,4,5].reduce([], &Ramda.pipe(
+        mapping   { |v| v + 1   },
+        filtering { |v| v.even? },
+        mapping   { |v| v * 3   }
+      ).call(concats))
+      expect(result).to eq [7, 13]
+    end
+  end
 end


### PR DESCRIPTION
* Add test for invalid implementation that's pretty easy to mistakenly do
* Add backticks on the commented out shell command since that allows you to uncomment it and run it from the editor.
* Copy tests from the bottom of transducers into the RSpec test suite
* Some transducers take a block, but call yield. I was about to remove the argument, but then thought that maybe you did that intentionally for documentation, so I left it.
* I kinda wanted to rename `concats` to `appends` since I'd expect `concats` to call `concat` or `+` instead of `push`, but felt like it wasn't my call, so left it alone :P FWIW, I don't really understand what transducers are, but was able to follow the expectations to wire it all up.

Anyway, it was fun to go through, ty ty ^_^